### PR TITLE
[PATCH] FTL-6 Public on PyPi

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default Owner of everything
+* @Jakob-Daugherty

--- a/.github/config/markdown-config.yaml
+++ b/.github/config/markdown-config.yaml
@@ -1,0 +1,140 @@
+default: false # includes/excludes all rules by default
+
+# Heading levels should only increment by one level at a time <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md001>
+MD001: true
+
+# Heading style <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md003>
+MD003: true
+
+# Unordered list style <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md004>
+MD004: true
+
+# Inconsistent indentation for list items at the same level <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md005>
+MD005: true
+
+# Consider starting bulleted lists at the beginning of the line <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md006>
+MD006: true
+
+# Unordered list indentation <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md007>
+MD007: true
+
+# Trailing spaces <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md009>
+MD009: true
+
+# Hard tabs <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md010>
+MD010: true
+
+# Reversed link syntax <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md011>
+MD011: true
+
+# Multiple consecutive blank lines <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md012>
+MD012: true
+
+# Line length <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md013>
+MD013: false
+
+# Dollar signs used before commands without showing output <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md014>
+MD014: false
+
+# No space after hash on atx style heading <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md018>
+MD018: true
+
+# Multiple spaces after hash on atx style heading <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md019>
+MD019: true
+
+# No space inside hashes on closed atx style heading <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md020>
+MD020: true
+
+# Multiple spaces inside hashes on closed atx style heading <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md021>
+MD021: true
+
+# Headings should be surrounded by blank lines <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md022>
+MD022: true
+
+# Headings must start at the beginning of the line <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md023>
+MD023: true
+
+# Multiple headings with the same content <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md024>
+MD024:
+  allow_different_nesting: true
+
+# Multiple top level headings in the same document <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md025>
+MD025: true
+
+# Trailing punctuation in heading <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md026>
+MD026: true
+
+# Multiple spaces after blockquote symbol <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md027>
+MD027: true
+
+# Blank line inside blockquote <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md028>
+MD028: false
+
+# Ordered list item prefix <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md029>
+MD029:
+  style: 'one'
+
+# Spaces after list markers <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md030>
+MD030: true
+
+# Fenced code blocks should be surrounded by blank lines <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md031>
+MD031: true
+
+# Lists should be surrounded by blank lines <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md032>
+MD032: true
+
+# Inline HTML <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md033>
+MD033: true
+
+# Bare URL used <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md034>
+MD034: true
+
+# Horizontal rule style <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md035>
+MD035:
+  style: '---'
+
+# Emphasis used instead of a heading <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md036>
+MD036: true
+
+# Spaces inside emphasis markers <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md037>
+MD037: true
+
+# Spaces inside code span elements <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md038>
+MD038: true
+
+# Spaces inside link text <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md039>
+MD039: true
+
+# Fenced code blocks should have a language specified <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md040>
+MD040: true
+
+# First line in file should be a top level heading <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md041>
+MD041: true
+
+# No empty links <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md042>
+MD042: true
+
+# Required heading structure <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md043>
+MD043: false
+
+# Proper names should have the correct capitalization <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md044>
+MD044: false
+
+# Images should have alternate text (alt text) <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md045>
+MD045: false
+
+# Code block style <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md046>
+MD046:
+  style: 'fenced'
+
+# Files should end with a single newline character <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md047>
+MD047: true
+
+# Code fence style <https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md048>
+MD048:
+  style: 'backtick'
+
+# Custom rules:
+#CHANGELOG-RULE-001: true
+#CHANGELOG-RULE-002: true
+#CHANGELOG-RULE-003: true

--- a/.github/config/markdown-rules.js
+++ b/.github/config/markdown-rules.js
@@ -1,0 +1,72 @@
+"use strict";
+
+module.exports = [{
+    names: ["CHANGELOG-RULE-001"],
+    description: "Version header format",
+    tags: ["headings", "headers", "changelog"],
+    function: (params, onError) => {
+        params.tokens.filter(function filterToken(token) {
+            return token.type === "heading_open";
+        }).forEach(function forToken(token) {
+            if (token.tag === "h2") {
+                if (/^## [vV]?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+|)$/m.test(token.line)) {
+                    return;
+                }
+
+                if (/^## [vV]?\d+\.\d+\.\d+(-[0-9A-Za-z-.]+|) - 20[12][0-9]-[01][0-9]-[0-3][0-9]$/m.test(token.line)) {
+                    return;
+                }
+
+                if (/^## unreleased$/mi.test(token.line)) {
+                    return;
+                }
+
+                return onError({
+                    lineNumber: token.lineNumber,
+                    detail: "Allowed formats: 'vX.X.X(-pre.release)' or 'vX.X.X(-pre.release) - YYYY-MM-DD' or 'UNRELEASED'",
+                    context: token.line
+                });
+            }
+        });
+    }
+}, {
+    names: ["CHANGELOG-RULE-002"],
+    description: "Type of changes format",
+    tags: ["headings", "headers", "changelog"],
+    function: (params, onError) => {
+        params.tokens.filter(function filterToken(token) {
+            return token.type === "heading_open";
+        }).forEach(function forToken(token) {
+            if (token.tag === "h3") {
+                if (/^### (Added|Changed|Deprecated|Removed|Fixed|Security)$/m.test(token.line)) {
+                    return;
+                }
+
+                return onError({
+                    lineNumber: token.lineNumber,
+                    detail: "Allowed types is: Added, Changed, Deprecated, Removed, Fixed or Security",
+                    context: token.line
+                });
+            }
+        });
+    }
+}, {
+    names: ["CHANGELOG-RULE-003"],
+    description: "Lists items without punctuation at the end",
+    tags: ["lists", "changelog"],
+    function: (params, onError) => {
+        params.tokens.filter(function filterToken(token) {
+            return token.type === "list_item_open";
+        }).forEach(function forToken(token) {
+            if (token.tag === "li") {
+                if (/[;,\.]$/m.test(token.line)) {
+                    return onError({
+                        lineNumber: token.lineNumber,
+                        detail: "'.', ';' or ',' at the end of list entry",
+                        context: token.line
+                    });
+                }
+            }
+        });
+    }
+}];

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,0 +1,19 @@
+name: Markdown
+
+on: [push]
+
+jobs:
+  lint-markdown:
+    name: Lint Markdown Files
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: check out code
+        uses: actions/checkout@v2
+        
+      - name: lint markdown files
+        uses: docker://avtodev/markdown-lint:v1
+        with:
+          rules: './.github/config/markdown-rules.js'
+          config: './.github/config/markdown-config.yaml'
+          ignore: './CHANGELOG.md'
+          args: '.'

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# ftlengine
+# FTL Engine
+
 FTL Engine

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# FTL Engine 
+# FTL Engine
 
 FTL Engine

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# FTL Engine
+# FTL Engine 
 
 FTL Engine

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="ftlengine",
+    version="0.0.1",
+    author="Jakob Daugherty",
+    author_email="jakob.daugherty@quarkworks.co",
+    description="A Docker based development and deployment engine",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/Jakob-Daugherty/ftlengine",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.6',
+)

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,19 @@
-import setuptools
+from setuptools import setup, find_packages
+from src import __version__
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(
+setup(
     name="ftlengine",
-    version="0.0.1",
+    version=__version__,
     author="Jakob Daugherty",
     author_email="jakob.daugherty@quarkworks.co",
     description="A Docker based development and deployment engine",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/Jakob-Daugherty/ftlengine",
-    packages=setuptools.find_packages(),
+    packages=find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+from src.version import __version__, __version_info__  # noqa

--- a/src/version.py
+++ b/src/version.py
@@ -1,0 +1,2 @@
+__version_info__ = (0, 0, 1)
+__version__ = '-'.join(filter(None, ['.'.join(map(str, __version_info__[:3])), (__version_info__[3:] or [None])[0]]))

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,8 @@
+from invoke_release.tasks import *  # noqa: F403
+
+configure_release_parameters(  # noqa: F405
+    module_name='src',
+    display_name='FTL',
+    use_pull_request=True,
+    use_tag=True,
+)


### PR DESCRIPTION
FTL-6 Project is now public on PyPi

Changes:
- Added GitHub CI pipelines for linting Markdown files
- Configured Repo
- Added Code owners files
- Confirgured Setup.py initially 